### PR TITLE
Upgraded Cabal bounds to use ghc >= 7.10

### DIFF
--- a/Language/Python/Pickle.hs
+++ b/Language/Python/Pickle.hs
@@ -539,7 +539,7 @@ addToDict l (Dict d) = Dict $ foldl' add d l
 ----------------------------------------------------------------------
 
 newtype Pickler a = Pickler { runP :: WriterT [OpCode] (State (Map Value Int)) a }
-  deriving (Monad, MonadWriter [OpCode], MonadState (Map Value Int))
+  deriving (Functor, Applicative, Monad, MonadWriter [OpCode], MonadState (Map Value Int))
 
 runPickler :: Pickler () -> [OpCode]
 runPickler p = evalState (execWriterT (runP p)) M.empty

--- a/default.nix
+++ b/default.nix
@@ -1,37 +1,21 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "default" }:
-
-let
-
-  inherit (nixpkgs) pkgs;
-
-  f = { mkDerivation, attoparsec, base, bytestring, cereal, cmdargs
-      , containers, directory, HUnit, mtl, process, stdenv
-      , test-framework, test-framework-hunit
-      }:
-      mkDerivation {
-        pname = "python-pickle";
-        version = "0.2.2";
-        src = ./.;
-        isLibrary = true;
-        isExecutable = true;
-        libraryHaskellDepends = [
-          attoparsec base bytestring cereal containers mtl
-        ];
-        executableHaskellDepends = [ base bytestring cmdargs ];
-        testHaskellDepends = [
-          base bytestring containers directory HUnit process test-framework
-          test-framework-hunit
-        ];
-        description = "Serialization/deserialization using Python Pickle format";
-        license = stdenv.lib.licenses.bsd3;
-      };
-
-  haskellPackages = if compiler == "default"
-                       then pkgs.haskellPackages
-                       else pkgs.haskell.packages.${compiler};
-
-  drv = haskellPackages.callPackage f {};
-
-in
-
-  if pkgs.lib.inNixShell then drv.env else drv
+{ mkDerivation, attoparsec, base, bytestring, cereal, cmdargs
+, containers, directory, HUnit, mtl, process, stdenv
+, test-framework, test-framework-hunit
+}:
+mkDerivation {
+  pname = "python-pickle";
+  version = "0.2.2";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    attoparsec base bytestring cereal containers mtl
+  ];
+  executableHaskellDepends = [ base bytestring cmdargs ];
+  testHaskellDepends = [
+    base bytestring containers directory HUnit process test-framework
+    test-framework-hunit
+  ];
+  description = "Serialization/deserialization using Python Pickle format";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,37 @@
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "default" }:
+
+let
+
+  inherit (nixpkgs) pkgs;
+
+  f = { mkDerivation, attoparsec, base, bytestring, cereal, cmdargs
+      , containers, directory, HUnit, mtl, process, stdenv
+      , test-framework, test-framework-hunit
+      }:
+      mkDerivation {
+        pname = "python-pickle";
+        version = "0.2.2";
+        src = ./.;
+        isLibrary = true;
+        isExecutable = true;
+        libraryHaskellDepends = [
+          attoparsec base bytestring cereal containers mtl
+        ];
+        executableHaskellDepends = [ base bytestring cmdargs ];
+        testHaskellDepends = [
+          base bytestring containers directory HUnit process test-framework
+          test-framework-hunit
+        ];
+        description = "Serialization/deserialization using Python Pickle format";
+        license = stdenv.lib.licenses.bsd3;
+      };
+
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
+
+  drv = haskellPackages.callPackage f {};
+
+in
+
+  if pkgs.lib.inNixShell then drv.env else drv

--- a/python-pickle.cabal
+++ b/python-pickle.cabal
@@ -17,21 +17,21 @@ source-repository head
   location: https://github.com/noteed/python-pickle
 
 library
-  build-depends:       attoparsec == 0.10.*,
+  build-depends:       attoparsec == 0.13.*,
                        base == 4.*,
-                       bytestring == 0.9.*,
-                       cereal == 0.3.*,
-                       containers == 0.4.*,
-                       mtl == 2.0.*
+                       bytestring == 0.10.*,
+                       cereal == 0.5.*,
+                       containers == 0.5.*,
+                       mtl == 2.2.*
   exposed-modules:     Language.Python.Pickle
   ghc-options:         -Wall
 
 executable pickle
   main-is:             pickle.hs
   hs-source-dirs:      bin/
-  build-depends:       base == 4.*,
-                       bytestring == 0.9.*,
-                       cmdargs == 0.9.*,
+  build-depends:       base,
+                       bytestring == 0.10.*,
+                       cmdargs == 0.10.*,
                        python-pickle
   ghc-options:         -Wall
 
@@ -41,14 +41,14 @@ test-suite pickled-values
   type: exitcode-stdio-1.0
 
   build-depends:
-    base,
-    bytestring == 0.9.*,
-    containers == 0.4.*,
-    directory == 1.1.*,
-    HUnit == 1.2.*,
+    base == 4.*,
+    bytestring == 0.10.*,
+    containers == 0.5.*,
+    directory == 1.2.*,
+    HUnit == 1.3.*,
     python-pickle,
-    process == 1.1.*,
-    test-framework == 0.7.*,
+    process == 1.4.*,
+    test-framework == 0.8.*,
     test-framework-hunit == 0.3.*
 
   ghc-options: -Wall

--- a/python-pickle.cabal
+++ b/python-pickle.cabal
@@ -47,7 +47,7 @@ test-suite pickled-values
     directory == 1.2.*,
     HUnit == 1.3.*,
     python-pickle,
-    process == 1.4.*,
+    process > 1.2 && <= 1.4,
     test-framework == 0.8.*,
     test-framework-hunit == 0.3.*
 

--- a/python-pickle.cabal
+++ b/python-pickle.cabal
@@ -47,7 +47,7 @@ test-suite pickled-values
     directory == 1.2.*,
     HUnit == 1.3.*,
     python-pickle,
-    process > 1.2 && <= 1.4,
+    process > 1.2 && <= 1.5,
     test-framework == 0.8.*,
     test-framework-hunit == 0.3.*
 


### PR DESCRIPTION
Now this package doesn't build with ghcs before 7.10 but I dont think most people care. If you do care just don't accept the PR. 