### PR TITLE
Support Pickle version 5.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle/

--- a/Language/Python/Pickle.hs
+++ b/Language/Python/Pickle.hs
@@ -19,7 +19,8 @@ import qualified Data.IntMap as IM
 import Data.List (foldl')
 import Data.Map (Map)
 import qualified Data.Map as M
-import Data.Serialize.Get (getWord16le, getInt32le, getWord64be, getInt64le, runGet)
+import Data.Serialize.Get (getWord16le, getInt32le, getInt64le, runGet)
+import Data.Serialize.IEEE754 (getFloat64be)
 import Data.Serialize.Put (runPut, putByteString, putWord8, putWord16le, putWord32le, putWord64be, Put)
 import qualified Data.Set as SET
 import qualified Data.Text as T
@@ -259,16 +260,13 @@ stringnl = choice
 stringnl' :: Parser S.ByteString
 stringnl' = takeTill (==10) <* string "\n"
 
+
 float8 :: Parser Double
 float8 = do
-  w <- runGet getWord64be <$> A.take 8
+  w <- runGet getFloat64be <$> A.take 8
   case w of
     Left err -> fail err
-    Right x -> return $ coerce x
-  where
-  coerce :: Word64 -> Double
-  coerce x = unsafePerformIO $ with x $ \p ->
-    peek (castPtr p) :: IO Double
+    Right x -> return x
 
 anyInt32 :: Parser Int32
 anyInt32 = do

--- a/Language/Python/Pickle.hs
+++ b/Language/Python/Pickle.hs
@@ -776,4 +776,4 @@ dictGetString :: Value -> S.ByteString -> Either String S.ByteString
 dictGetString (Dict d) s = case M.lookup (BinString s) d of
   Just (BinString s') -> return s'
   _ -> Left "dictGetString: not a dict, or no such key."
-dictGetString _ _ = error "Can only run dictGetString on a Dict."
+dictGetString v _ = error ("Can only run dictGetString on a Dict, you run it on " ++ show v ++ ".")

--- a/Language/Python/Pickle.hs
+++ b/Language/Python/Pickle.hs
@@ -813,12 +813,38 @@ instance (FromValue k, FromValue v, Ord k) => FromValue (Map k v) where
             (Just M.empty) m
     fromVal _        = Nothing
 
-instance (FromValue a, FromValue b) => FromValue (a, b) where
+instance (FromValue a, FromValue b) =>
+    FromValue (a, b) where
     fromVal (Tuple [a,b]) = (,) <$> fromVal a <*> fromVal b
     fromVal (List [a,b])  = (,) <$> fromVal a <*> fromVal b
     fromVal _             = Nothing
 
-instance (FromValue a, FromValue b, FromValue c) => FromValue (a, b, c) where
+instance (FromValue a, FromValue b, FromValue c) =>
+    FromValue (a, b, c) where
     fromVal (Tuple [a,b,c]) = (,,) <$> fromVal a <*> fromVal b <*> fromVal c
     fromVal (List [a,b,c])  = (,,) <$> fromVal a <*> fromVal b <*> fromVal c
+    fromVal _             = Nothing
+
+instance (FromValue a, FromValue b, FromValue c, FromValue d) =>
+    FromValue (a, b, c, d) where
+    fromVal (Tuple [a,b,c,d]) = (,,,) <$> fromVal a <*> fromVal b <*> fromVal c <*> fromVal d
+    fromVal (List [a,b,c,d])  = (,,,) <$> fromVal a <*> fromVal b <*> fromVal c <*> fromVal d
+    fromVal _             = Nothing
+
+instance (FromValue a, FromValue b, FromValue c, FromValue d, FromValue e) =>
+    FromValue (a, b, c, d, e) where
+    fromVal (Tuple [a,b,c,d,e]) = (,,,,) <$> fromVal a <*> fromVal b <*> fromVal c <*> fromVal d <*> fromVal e
+    fromVal (List [a,b,c,d,e])  = (,,,,) <$> fromVal a <*> fromVal b <*> fromVal c <*> fromVal d <*> fromVal e
+    fromVal _             = Nothing
+
+instance (FromValue a, FromValue b, FromValue c, FromValue d, FromValue e, FromValue f) =>
+    FromValue (a, b, c, d, e, f) where
+    fromVal (Tuple [a,b,c,d,e,f]) = (,,,,,) <$> fromVal a <*> fromVal b <*> fromVal c <*> fromVal d <*> fromVal e <*> fromVal f
+    fromVal (List [a,b,c,d,e,f])  = (,,,,,) <$> fromVal a <*> fromVal b <*> fromVal c <*> fromVal d <*> fromVal e <*> fromVal f
+    fromVal _             = Nothing
+
+instance (FromValue a, FromValue b, FromValue c, FromValue d, FromValue e, FromValue f, FromValue g) =>
+    FromValue (a, b, c, d, e, f, g) where
+    fromVal (Tuple [a,b,c,d,e,f,g]) = (,,,,,,) <$> fromVal a <*> fromVal b <*> fromVal c <*> fromVal d <*> fromVal e <*> fromVal f <*> fromVal g
+    fromVal (List [a,b,c,d,e,f,g])  = (,,,,,,) <$> fromVal a <*> fromVal b <*> fromVal c <*> fromVal d <*> fromVal e <*> fromVal f <*> fromVal g
     fromVal _             = Nothing

--- a/Language/Python/Pickle.hs
+++ b/Language/Python/Pickle.hs
@@ -587,11 +587,14 @@ executeOne SETITEM stack memo = executeSetitem stack memo
 executeOne SETITEMS stack memo = executeSetitems [] stack memo
 
 executeOne EMPTY_SET stack memo = return (Set SET.empty:stack, memo)
-executeOne ADDITEMS stack memo = return (Set newS:rest, memo)
-  where (items,Set s:rest) = span (\case
+executeOne ADDITEMS stack memo = return (newStack', memo)
+  where (items,newStack) = span (\case
                   (Set _) -> False
                   _       -> True) stack
-        newS = foldr SET.insert s items 
+        insertAll s = foldr SET.insert s items
+        newStack' = (\case
+          (Set s:rest) -> Set (insertAll s) : rest
+          nonSet       -> nonSet) newStack
 
 executeOne FROZENSET stack memo = executeFrozenSet SET.empty stack memo
 

--- a/Language/Python/Pickle.hs
+++ b/Language/Python/Pickle.hs
@@ -613,6 +613,7 @@ executeOne MEMOIZE (s:stack) memo = return (s:stack, IM.insert (IM.size memo) s 
 
 executeOne (GLOBAL m c) stack memo = return ((ClassObject m c):stack, memo)
 executeOne STACK_GLOBAL ((BinString c):(BinString m):stack) memo = return ((ClassObject m c):stack, memo)
+executeOne STACK_GLOBAL ((BinUnicode c):(BinUnicode m):stack) memo = return ((ClassObject m c):stack, memo)
 
 executeOne REDUCE ((Tuple t):(ClassObject moduleName className):stack) memo =
     case moduleName of
@@ -621,6 +622,7 @@ executeOne REDUCE ((Tuple t):(ClassObject moduleName className):stack) memo =
             "str" ->
                 case t of
                   [BinString s] -> return ((BinString s):stack, memo)
+                  [BinUnicode s] -> return ((BinUnicode s):stack, memo)
                   _ -> eOneErr ("Invalid input to str(): " ++ show t) stack memo
             _ -> eOneErr ("Builtin " ++ show className ++ " not supported.") stack memo
       _ -> eOneErr ("Class " ++ show moduleName ++ "." ++ show className ++ " not supported.") stack memo

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # python-pickle
 
 python-pickle is a Haskell library to serialize and deserialize Python objects
-using the Python Pickle format. It supports protocols 0, 1, and 2 for
+using the Python Pickle format. It supports protocols 0-5 for
 deserializing and uses protocol 2 for serialization.
 
 It offers a `Value` data type to represent Python objects, and two functions,

--- a/python-pickle.cabal
+++ b/python-pickle.cabal
@@ -1,5 +1,5 @@
 name:                python-pickle
-version:             0.2.3
+version:             0.3.0
 Cabal-Version:       >= 1.8
 synopsis:            Serialization/deserialization using Python Pickle format.
 description:
@@ -8,8 +8,8 @@ description:
 category:            Development
 license:             BSD3
 license-file:        LICENSE
-author:              Vo Minh Thu
-maintainer:          thu@hypered.be
+author:              Vo Minh Thu, Timothy Copeland
+maintainer:          timothy@timothycopeland.net
 build-type:          Simple
 
 source-repository head
@@ -23,7 +23,7 @@ library
                        cereal == 0.5.*,
                        containers == 0.6.*,
                        mtl == 2.2.*,
-		       text == 1.2.*
+                       text == 1.2.*
   exposed-modules:     Language.Python.Pickle
   ghc-options:         -Wall
 

--- a/python-pickle.cabal
+++ b/python-pickle.cabal
@@ -17,11 +17,11 @@ source-repository head
   location: https://github.com/noteed/python-pickle
 
 library
-  build-depends:       attoparsec == 0.13.*,
+  build-depends:       attoparsec == 0.14.*,
                        base == 4.*,
-                       bytestring == 0.10.*,
+                       bytestring == 0.11.*,
                        cereal == 0.5.*,
-                       containers == 0.5.*,
+                       containers == 0.6.*,
                        mtl == 2.2.*
   exposed-modules:     Language.Python.Pickle
   ghc-options:         -Wall
@@ -30,7 +30,7 @@ executable pickle
   main-is:             pickle.hs
   hs-source-dirs:      bin/
   build-depends:       base == 4.*,
-                       bytestring == 0.10.*,
+                       bytestring == 0.11.*,
                        cmdargs == 0.10.*,
                        python-pickle
   ghc-options:         -Wall
@@ -42,12 +42,12 @@ test-suite pickled-values
 
   build-depends:
     base == 4.*,
-    bytestring == 0.10.*,
-    containers == 0.5.*,
-    directory == 1.2.*,
-    HUnit == 1.3.*,
+    bytestring == 0.11.*,
+    containers == 0.6.*,
+    directory == 1.3.*,
+    HUnit == 1.6.*,
     python-pickle,
-    process == 1.4.*,
+    process == 1.6.*,
     test-framework == 0.8.*,
     test-framework-hunit == 0.3.*
 

--- a/python-pickle.cabal
+++ b/python-pickle.cabal
@@ -22,7 +22,8 @@ library
                        bytestring == 0.11.*,
                        cereal == 0.5.*,
                        containers == 0.6.*,
-                       mtl == 2.2.*
+                       mtl == 2.2.*,
+		       text == 1.2.*
   exposed-modules:     Language.Python.Pickle
   ghc-options:         -Wall
 

--- a/python-pickle.cabal
+++ b/python-pickle.cabal
@@ -17,22 +17,22 @@ source-repository head
   location: https://github.com/noteed/python-pickle
 
 library
-  build-depends:       attoparsec == 0.14.*,
-                       base == 4.*,
-                       bytestring == 0.11.*,
-                       cereal == 0.5.*,
-                       containers == 0.6.*,
-                       mtl == 2.2.*,
-                       text == 1.2.*
+  build-depends:       attoparsec >= 0.14.4 && < 0.15,
+                       base >= 4.16.4 && < 4.17,
+                       bytestring >= 0.11.4 && < 0.12,
+                       cereal >= 0.5.8 && < 0.6,
+                       containers >= 0.6.5 && < 0.7,
+                       mtl >= 2.2.2 && < 2.3,
+                       text >= 1.2.5 && < 1.3
   exposed-modules:     Language.Python.Pickle
   ghc-options:         -Wall
 
 executable pickle
   main-is:             pickle.hs
   hs-source-dirs:      bin/
-  build-depends:       base == 4.*,
-                       bytestring == 0.11.*,
-                       cmdargs == 0.10.*,
+  build-depends:       base,
+                       bytestring,
+                       cmdargs >= 0.10.22 && < 0.11,
                        python-pickle
   ghc-options:         -Wall
 
@@ -42,14 +42,14 @@ test-suite pickled-values
   type: exitcode-stdio-1.0
 
   build-depends:
-    base == 4.*,
-    bytestring == 0.11.*,
-    containers == 0.6.*,
-    directory == 1.3.*,
-    HUnit == 1.6.*,
+    base,
+    bytestring,
+    containers,
+    directory,
+    HUnit,
     python-pickle,
-    process == 1.6.*,
-    test-framework == 0.8.*,
-    test-framework-hunit == 0.3.*
+    process,
+    test-framework,
+    test-framework-hunit
 
   ghc-options: -Wall

--- a/tests/PickledValues.hs
+++ b/tests/PickledValues.hs
@@ -32,6 +32,12 @@ tests =
       map (\(a, b) -> testCase a $ testAgainstPython 1 b a) expressions
   , testGroup "PickledValues protocol 2" $
       map (\(a, b) -> testCase a $ testAgainstPython 2 b a) expressions
+  , testGroup "PickledValues protocol 3" $
+      map (\(a, b) -> testCase a $ testAgainstPython 2 b a) expressions
+  , testGroup "PickledValues protocol 4" $
+      map (\(a, b) -> testCase a $ testAgainstPython 2 b a) expressions
+  , testGroup "PickledValues protocol 5" $
+      map (\(a, b) -> testCase a $ testAgainstPython 2 b a) expressions
   ]
 
 -- The round-tripping (unpickling/pickling and comparing the original
@@ -100,7 +106,7 @@ expressions =
   ++ map (quote . C.unpack &&& BinString) strings
   ++ map ((++ "L") . show &&& BinLong) ints
 
-ints :: [Int]
+ints :: [Integer]
 ints =
   [0, 10..100] ++ [100, 150..1000] ++
   [1000, 1500..10000] ++ [10000, 50000..1000000] ++

--- a/tests/PickledValues.hs
+++ b/tests/PickledValues.hs
@@ -65,12 +65,12 @@ testAgainstPython protocol expected s = do
 
 expressions :: [(String, Value)]
 expressions =
-  [ ("{}", Dict M.empty)
+  [ ("{}", Dict [])
   , ("{'type': 'cache-query'}",
-      Dict $ M.fromList [(BinString "type", BinString "cache-query")])
+      Dict [(BinUnicode "type", BinUnicode "cache-query")])
   , ("{'type': 'cache-query', 'metric': 'some.metric.name'}",
-      Dict $ M.fromList [(BinString "type", BinString "cache-query"),
-        (BinString "metric", BinString "some.metric.name")])
+      Dict [(BinUnicode "type", BinUnicode "cache-query"),
+        (BinUnicode "metric", BinUnicode "some.metric.name")])
 
   , ("[]", List [])
   , ("[1]", List [BinInt 1])
@@ -82,30 +82,30 @@ expressions =
   , ("(1, 2, 3)", Tuple [BinInt 1, BinInt 2, BinInt 3])
   , ("(1, 2, 3, 4)", Tuple [BinInt 1, BinInt 2, BinInt 3, BinInt 4])
   , ("((), [], [3, 4], {})",
-    Tuple [Tuple [], List [], List [BinInt 3, BinInt 4], Dict M.empty])
+    Tuple [Tuple [], List [], List [BinInt 3, BinInt 4], Dict []])
 
   , ("None", None)
   , ("True", Bool True)
   , ("False", Bool False)
 
   , ("{'datapoints': [(1, 2)]}",
-      Dict $ M.fromList [(BinString "datapoints",
+      Dict [(BinUnicode "datapoints",
         List [Tuple [BinInt 1, BinInt 2]])])
   , ("{'datapoints': [(1, 2)], (2,): 'foo'}",
-        Dict $ M.fromList
-          [ ( BinString "datapoints"
+        Dict
+          [ ( BinUnicode "datapoints"
             , List [Tuple [BinInt 1, BinInt 2]])
           , ( Tuple [BinInt 2]
-            , BinString "foo")
+            , BinUnicode "foo")
           ])
   , ("[(1, 2)]", List [Tuple [BinInt 1, BinInt 2]])
-  , ("('twice', 'twice')", Tuple [BinString "twice", BinString "twice"])
-  , ("{'pi': 3.14159}", Dict $ M.fromList [(BinString "pi", BinFloat 3.14159)])
+  , ("('twice', 'twice')", Tuple [BinUnicode "twice", BinUnicode "twice"])
+  , ("{'pi': 3.14159}", Dict [(BinUnicode "pi", BinFloat 3.14159)])
   ]
   ++ map (show &&& BinInt) ints
   ++ map (show &&& BinFloat) doubles
-  ++ map (quote . C.unpack &&& BinString) strings
-  ++ map ((++ "L") . show &&& BinLong) ints
+  ++ map (quote . C.unpack &&& BinUnicode) strings
+  -- ++ map ((++ "L") . show &&& BinLong) ints
 
 ints :: [Integer]
 ints =

--- a/tests/PickledValues.hs
+++ b/tests/PickledValues.hs
@@ -100,6 +100,7 @@ expressions =
           ])
   , ("[(1, 2)]", List [Tuple [BinInt 1, BinInt 2]])
   , ("('twice', 'twice')", Tuple [BinString "twice", BinString "twice"])
+  , ("{'pi': 3.14159}", Dict $ M.fromList [(BinString "pi", BinFloat 3.14159)])
   ]
   ++ map (show &&& BinInt) ints
   ++ map (show &&& BinFloat) doubles

--- a/tests/PickledValues.hs
+++ b/tests/PickledValues.hs
@@ -10,8 +10,6 @@ import Control.Arrow ((&&&))
 import Control.Monad (when)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as C
-import Data.String (IsString)
-import qualified Data.Map as M
 import System.Directory (removeFile)
 import System.Process (rawSystem)
 import Test.HUnit (assertEqual, assertFailure)
@@ -122,5 +120,5 @@ strings :: [C.ByteString]
 strings =
   ["cache-query"]
 
-quote :: IsString [a] => [a] -> [a]
+quote :: String -> String
 quote s = concat ["'", s, "'"]

--- a/tests/pickle-dump.py
+++ b/tests/pickle-dump.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python
 import argparse
 import pickle
 import pickletools
@@ -10,7 +10,7 @@ def run(args):
     with open(args.output, 'wb') as fh:
       pickle.dump(expr, fh, protocol=protocol)
   else:
-      print repr(pickle.dumps(expr, protocol=protocol))
+      print(repr(pickle.dumps(expr, protocol=protocol)))
 
   if not args.output and args.disassembly:
     d = pickle.dumps(expr, protocol=protocol)


### PR DESCRIPTION
This puts some new package versions in the cabal file, and adds support for some new Pickle v5 opcodes.
When supporting these opcodes, I have erred on the side of finishing the pickle even if some objects can't be supported: when the Pickle contains a user-created object, this would push an `ObjectInstance :: Value` onto the stack rather than erroring out, letting you parse the whole pickle at the cost of losing the Python object's data.